### PR TITLE
Use gpg directly instead of gpg2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
         if [ "$PROFILE" = "ossrh" ]
         then
           echo "$ZEPBEN_GPG_KEY" | base64 -d > zepben-gpg.key
-          gpg2 --batch --import zepben-gpg.key
+          gpg --batch --import zepben-gpg.key
           if [ -z $SETTINGS_PATH ]
           then
             mvn clean deploy -f $POM_PATH -P 'release,ossrh,!zepben-maven' -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dossrh.server.username=$OSSRH_USERNAME -Dossrh.server.password=$OSSRH_PASSWORD -Dgpg.key=$GPG_KEY_ID -Dgpg.password=$GPG_KEY_PASSWORD


### PR DESCRIPTION
# Description

In Amazon Linux gpg2 is a soft link to gpg. In Debian gpg2 doesn't exist.

This change uses gpg binary directly.

# Test Steps

I've ran debian container and tested the command `gpg --batch --import` and it seems to be supported, so no further issues expected at this time.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).