### PR TITLE
[DEV-10080] Always include git information inside jars for private builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -97,9 +97,9 @@ runs:
           if [ -z $SETTINGS_PATH ]
           then
             # -B for batch mode to make progress spam go away hopefully
-            mvn clean deploy -B -f $POM_PATH -P 'zepben-maven' -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
+            mvn clean deploy -B -f $POM_PATH -P 'zepben-maven' -Dadd.git.info=true -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           else
-            mvn clean deploy -B -f $POM_PATH -P 'zepben-maven' -s $SETTINGS_PATH -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
+            mvn clean deploy -B -f $POM_PATH -P 'zepben-maven' -s $SETTINGS_PATH -Dadd.git.info=true -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dserver.release.url=$NEXUS_RELEASE_URL -Dserver.snapshot.url=$NEXUS_SNAPSHOT_URL
           fi
         fi
         artifactId=$(xmlstarlet pyx $POM_PATH | grep -v ^A | xmlstarlet p2x | xmlstarlet sel -t -v "/project/artifactId")

--- a/action.yml
+++ b/action.yml
@@ -88,9 +88,9 @@ runs:
           if [ -z $SETTINGS_PATH ]
           then
             # -B for batch mode to make progress spam go away hopefully
-            mvn clean deploy -B -f $POM_PATH -P 'release,maven-central,!zepben-maven' -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dmaven-central.server.username=$MAVEN_CENTRAL_USERNAME -Dmaven-central.server.password=$MAVEN_CENTRAL_PASSWORD -Dgpg.key=$GPG_KEY_ID -Dgpg.password=$GPG_KEY_PASSWORD
+            mvn clean deploy -B -f $POM_PATH -P 'release,maven-central,!zepben-maven' -Dadd.git.info=true -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dmaven-central.server.username=$MAVEN_CENTRAL_USERNAME -Dmaven-central.server.password=$MAVEN_CENTRAL_PASSWORD -Dgpg.key=$GPG_KEY_ID -Dgpg.password=$GPG_KEY_PASSWORD
           else
-            mvn clean deploy -B -f $POM_PATH -P 'release,maven-central,!zepben-maven' -s $SETTINGS_PATH -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dmaven-central.server.username=$MAVEN_CENTRAL_USERNAME -Dmaven-central.server.password=$MAVEN_CENTRAL_PASSWORD -Dgpg.key=$GPG_KEY_ID -Dgpg.password=$GPG_KEY_PASSWORD
+            mvn clean deploy -B -f $POM_PATH -P 'release,maven-central,!zepben-maven' -s $SETTINGS_PATH -Dadd.git.info=true -Dserver.repo.url=$NEXUS_MAVEN_REPO -Dserver.username=$NEXUS_USERNAME -Dserver.password=$NEXUS_PASSWORD -Dmaven-central.server.username=$MAVEN_CENTRAL_USERNAME -Dmaven-central.server.password=$MAVEN_CENTRAL_PASSWORD -Dgpg.key=$GPG_KEY_ID -Dgpg.password=$GPG_KEY_PASSWORD
           fi
         elif [ "$PROFILE" = "zepben-maven" ]
         then


### PR DESCRIPTION
# Description

This change will include git information (sha, commit, author, etc) of the commit from which the build was made in the file called `git.properties` inside the jar. Helpful for debugging.

Requires superpom `0.52.0` and above and inclusion of the plugin in the pom of the dependen app/lib.